### PR TITLE
Match resources to queries

### DIFF
--- a/mentions-generator/pom.xml
+++ b/mentions-generator/pom.xml
@@ -18,22 +18,18 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.9.9</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-core</artifactId>
-            <version>7.1.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-queryparser</artifactId>
-            <version>8.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.lucene</groupId>
             <artifactId>lucene-analyzers-common</artifactId>
-            <version>8.2.0</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -51,7 +47,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.9.9</version>
         </dependency>
     </dependencies>
 

--- a/mentions-generator/pom.xml
+++ b/mentions-generator/pom.xml
@@ -28,6 +28,11 @@
             <groupId>org.springframework.data</groupId>
             <artifactId>spring-data-jpa</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.9.9</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/mentions-generator/pom.xml
+++ b/mentions-generator/pom.xml
@@ -16,6 +16,26 @@
 
     <dependencies>
         <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <version>2.9.9</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-core</artifactId>
+            <version>7.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-queryparser</artifactId>
+            <version>8.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.lucene</groupId>
+            <artifactId>lucene-analyzers-common</artifactId>
+            <version>8.2.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>
         </dependency>

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/MentionsGeneratorApplication.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/MentionsGeneratorApplication.java
@@ -7,8 +7,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-import javax.annotation.PostConstruct;
-
 @SpringBootApplication
 public class MentionsGeneratorApplication {
 
@@ -25,10 +23,5 @@ public class MentionsGeneratorApplication {
     @Autowired
     private QueryRepository queryRepository;
 
-    @PostConstruct
-    public void matchMentionsOnQueries(){
-
-
-    }
 }
 

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/MentionsGeneratorApplication.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/MentionsGeneratorApplication.java
@@ -1,9 +1,5 @@
 package de.brandwatch.minianalytics.mentiongenerator;
 
-import de.brandwatch.minianalytics.mentiongenerator.kafka.Consumer;
-import de.brandwatch.minianalytics.mentiongenerator.kafka.Producer;
-import de.brandwatch.minianalytics.mentiongenerator.postgres.repository.QueryRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -13,15 +9,5 @@ public class MentionsGeneratorApplication {
     public static void main(String[] args) {
         SpringApplication.run(MentionsGeneratorApplication.class, args);
     }
-
-    @Autowired
-    private Producer producer;
-
-    @Autowired
-    private Consumer consumer;
-
-    @Autowired
-    private QueryRepository queryRepository;
-
 }
 

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/MentionsGeneratorApplication.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/MentionsGeneratorApplication.java
@@ -1,6 +1,8 @@
 package de.brandwatch.minianalytics.mentiongenerator;
 
+import de.brandwatch.minianalytics.mentiongenerator.kafka.Consumer;
 import de.brandwatch.minianalytics.mentiongenerator.kafka.Producer;
+import de.brandwatch.minianalytics.mentiongenerator.postgres.repository.QueryRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -17,9 +19,16 @@ public class MentionsGeneratorApplication {
     @Autowired
     private Producer producer;
 
+    @Autowired
+    private Consumer consumer;
+
+    @Autowired
+    private QueryRepository queryRepository;
+
     @PostConstruct
-    public void sendMessagesOnKafka() {
-        producer.send("Waz up?");
+    public void matchMentionsOnQueries(){
+
+
     }
 }
 

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
@@ -92,7 +92,7 @@ public class Consumer {
 
                 logger.info("Query " + query.getQueryID() + " hit on ressource " + ressource.getText());
 
-                //Create Ressource out of document
+                //Create Mention out of ressource
                 Mention mention = new Mention();
 
                 mention.setQueryID(query.getQueryID());
@@ -101,6 +101,8 @@ public class Consumer {
                 mention.setDate(ressource.getDate());
 
                 logger.info("Generated Mention: " + mention.toString());
+
+                producer.send(mention);
 
             }
         }

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
@@ -1,5 +1,6 @@
 package de.brandwatch.minianalytics.mentiongenerator.kafka;
 
+import de.brandwatch.minianalytics.mentiongenerator.model.Mention;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -9,8 +10,8 @@ public class Consumer {
     private static final Logger logger = LoggerFactory.getLogger(Consumer.class);
 
     @KafkaListener(topics = "twitter")
-    public void receive(String message){
-        logger.info("received message='{}'", message);
+    public void receive(Mention mention){
+        logger.info("received message='{}'", mention.toString());
     }
 }
 

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
@@ -13,12 +13,11 @@ import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.IndexWriter;
 import org.apache.lucene.index.IndexWriterConfig;
 import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParser;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.RAMDirectory;
-import org.apache.lucene.queryparser.classic.QueryParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,25 +31,24 @@ public class Consumer {
     private static final Logger logger = LoggerFactory.getLogger(Consumer.class);
 
     @Autowired
-    QueryRepository queryRepository;
+    private QueryRepository queryRepository;
 
     @Autowired
-    Producer producer;
+    private Producer producer;
 
-    Directory memoryIndex = new RAMDirectory();
-    StandardAnalyzer analyzer = new StandardAnalyzer();
+    private Directory memoryIndex = new RAMDirectory();
+    private StandardAnalyzer analyzer = new StandardAnalyzer();
 
-    IndexWriterConfig indexWriterConfig = new IndexWriterConfig(analyzer);
-    IndexWriter writer = new IndexWriter(memoryIndex, indexWriterConfig);
+    private IndexWriterConfig indexWriterConfig = new IndexWriterConfig(analyzer);
+    private IndexWriter writer = new IndexWriter(memoryIndex, indexWriterConfig);
 
-    IndexSearcher searcher;
-    IndexReader reader;
+    private IndexSearcher searcher;
+    private IndexReader reader;
 
-    QueryParser queryParser = new QueryParser("text", analyzer);
+    private QueryParser queryParser = new QueryParser("text", analyzer);
 
     public Consumer() throws IOException {
     }
-
 
     @KafkaListener(topics = "twitter")
     public void receive(Ressource ressource) throws ParseException, IOException {

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
@@ -30,15 +30,15 @@ public class Consumer {
 
     private static final Logger logger = LoggerFactory.getLogger(Consumer.class);
 
-    private QueryRepository queryRepository;
+    private final QueryRepository queryRepository;
 
-    private Producer producer;
+    private final Producer producer;
 
-    private Directory memoryIndex = new RAMDirectory();
-    private StandardAnalyzer analyzer = new StandardAnalyzer();
+    private final Directory memoryIndex = new RAMDirectory();
+    private final StandardAnalyzer analyzer = new StandardAnalyzer();
 
-    private IndexWriterConfig indexWriterConfig = new IndexWriterConfig(analyzer);
-    private IndexWriter writer = new IndexWriter(memoryIndex, indexWriterConfig);
+    private final IndexWriterConfig indexWriterConfig = new IndexWriterConfig(analyzer);
+    private final IndexWriter writer = new IndexWriter(memoryIndex, indexWriterConfig);
 
     private IndexSearcher searcher;
     private IndexReader reader;
@@ -51,7 +51,7 @@ public class Consumer {
         this.producer = producer;
     }
 
-    @KafkaListener(topics = "twitter")
+    @KafkaListener(topics = "resources")
     public void receive(Resource resource) throws ParseException, IOException {
         logger.info("received message='{}'", resource.toString());
 

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
@@ -43,7 +43,7 @@ public class Consumer {
     private IndexSearcher searcher;
     private IndexReader reader;
 
-    private QueryParser queryParser = new QueryParser("text", analyzer);
+    private final QueryParser queryParser = new QueryParser("text", analyzer);
 
     @Autowired
     public Consumer(QueryRepository queryRepository, Producer producer) throws IOException {

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
@@ -58,8 +58,8 @@ public class Consumer {
         //Create Lucene Document out of Resource
         Document document = new Document();
 
-        document.add(new TextField("author", resource.getAuthor(), Field.Store.YES));
-        document.add(new TextField("text", resource.getText(), Field.Store.YES));
+        document.add(new TextField("author", resource.getAuthor(), Field.Store.NO));
+        document.add(new TextField("text", resource.getText(), Field.Store.NO));
 
         logger.info("Indexed document:\n{\n\tauthor: " + document.get("author") + "\n\ttext: " + document.get("text") + "\n}");
 

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Consumer.java
@@ -1,17 +1,114 @@
 package de.brandwatch.minianalytics.mentiongenerator.kafka;
 
 import de.brandwatch.minianalytics.mentiongenerator.model.Mention;
+import de.brandwatch.minianalytics.mentiongenerator.model.Ressource;
+import de.brandwatch.minianalytics.mentiongenerator.postgres.model.Query;
+import de.brandwatch.minianalytics.mentiongenerator.postgres.repository.QueryRepository;
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.document.Document;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.TextField;
+import org.apache.lucene.index.DirectoryReader;
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.IndexWriter;
+import org.apache.lucene.index.IndexWriterConfig;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.TopDocs;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.RAMDirectory;
+import org.apache.lucene.queryparser.classic.QueryParser;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.annotation.KafkaListener;
+
+import java.io.IOException;
+import java.util.List;
 
 public class Consumer {
 
     private static final Logger logger = LoggerFactory.getLogger(Consumer.class);
 
+    @Autowired
+    QueryRepository queryRepository;
+
+    @Autowired
+    Producer producer;
+
+    Directory memoryIndex = new RAMDirectory();
+    StandardAnalyzer analyzer = new StandardAnalyzer();
+
+    IndexWriterConfig indexWriterConfig = new IndexWriterConfig(analyzer);
+    IndexWriter writer = new IndexWriter(memoryIndex, indexWriterConfig);
+
+    IndexSearcher searcher;
+    IndexReader reader;
+
+    QueryParser queryParser = new QueryParser("text", analyzer);
+
+    public Consumer() throws IOException {
+    }
+
+
     @KafkaListener(topics = "twitter")
-    public void receive(Mention mention){
-        logger.info("received message='{}'", mention.toString());
+    public void receive(Ressource ressource) throws ParseException, IOException {
+        logger.info("received message='{}'", ressource.toString());
+
+        //TODO Create Lucene Document out of Ressource
+        Document document = new Document();
+
+        document.add(new TextField("author", ressource.getAuthor(), Field.Store.YES));
+        document.add(new TextField("text", ressource.getText(), Field.Store.YES));
+
+        logger.info("Document text: " + document.get("text"));
+        logger.info("Document author: " + document.get("author"));
+
+        writer.addDocument(document);
+        writer.commit();
+
+        reader = DirectoryReader.open(memoryIndex);
+        searcher = new IndexSearcher(reader);
+
+
+        //TODO Fetch all Queries from Database -> Cache Queries
+        List<Query> queries = queryRepository.findAll();
+        logger.info("received " + queries.size() + " queries");
+
+
+        for (Query query : queries) {
+
+            org.apache.lucene.search.Query luceneQuery = queryParser.parse(query.toString());
+
+            logger.info("Search Query: " + luceneQuery.toString());
+
+            //The maximum of hits can only be 1 bcs. there is a maximum of 1 Document in the index
+            TopDocs topDocs = searcher.search(luceneQuery, 10);
+
+            logger.info("Total hits: " + topDocs.totalHits);
+
+            if (topDocs.totalHits == 1) {
+
+                logger.info("Query " + query.getQueryID() + " hit on ressource " + ressource.getText());
+
+                //Create Ressource out of document
+                Mention mention = new Mention();
+
+                mention.setQueryID(query.getQueryID());
+                mention.setAuthor(ressource.getAuthor());
+                mention.setText(ressource.getText());
+                mention.setDate(ressource.getDate());
+
+                logger.info("Generated Mention: " + mention.toString());
+
+            }
+        }
+
+        writer.deleteAll();
+        writer.commit();
+
+
     }
 }
 

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Producer.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Producer.java
@@ -10,10 +10,10 @@ public class Producer {
 
     private static final Logger logger = LoggerFactory.getLogger(Producer.class);
 
-    @Autowired
     private KafkaTemplate<String, Mention> kafkaTemplate;
 
-    public Producer() {
+    @Autowired
+    public Producer(KafkaTemplate<String, Mention> kafkaTemplate) {
     }
 
     public void send(Mention mention){

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Producer.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Producer.java
@@ -1,5 +1,7 @@
 package de.brandwatch.minianalytics.mentiongenerator.kafka;
 
+import de.brandwatch.minianalytics.mentiongenerator.model.Mention;
+import de.brandwatch.minianalytics.mentiongenerator.model.Ressource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,10 +12,10 @@ public class Producer {
     private static final Logger logger = LoggerFactory.getLogger(Producer.class);
 
     @Autowired
-    private KafkaTemplate<String, String> kafkaTemplate;
+    private KafkaTemplate<String, Mention> kafkaTemplate;
 
-    public void send(String message) {
-        logger.info("sending message='{}", message);
-        kafkaTemplate.send("mentions", "Hidwdae", message);
+    public void send(Mention mention){
+        logger.info("sending message='{}", mention);
+        kafkaTemplate.send("mentions",String.valueOf(System.currentTimeMillis()), mention);
     }
 }

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Producer.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Producer.java
@@ -1,7 +1,6 @@
 package de.brandwatch.minianalytics.mentiongenerator.kafka;
 
 import de.brandwatch.minianalytics.mentiongenerator.model.Mention;
-import de.brandwatch.minianalytics.mentiongenerator.model.Ressource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +12,9 @@ public class Producer {
 
     @Autowired
     private KafkaTemplate<String, Mention> kafkaTemplate;
+
+    public Producer() {
+    }
 
     public void send(Mention mention){
         logger.info("sending message='{}", mention);

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Producer.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/Producer.java
@@ -6,6 +6,8 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.kafka.core.KafkaTemplate;
 
+import java.time.Instant;
+
 public class Producer {
 
     private static final Logger logger = LoggerFactory.getLogger(Producer.class);
@@ -18,6 +20,6 @@ public class Producer {
 
     public void send(Mention mention){
         logger.info("sending message='{}", mention);
-        kafkaTemplate.send("mentions",String.valueOf(System.currentTimeMillis()), mention);
+        kafkaTemplate.send("mentions",String.valueOf(Instant.now()), mention);
     }
 }

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/config/ConsumerConfig.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/config/ConsumerConfig.java
@@ -43,11 +43,11 @@ public class ConsumerConfig {
     }
 
     @Bean
-    public ConsumerFactory<String, Object> consumerFactory(){
+    public ConsumerFactory<String, Resource> consumerFactory(){
         JsonDeserializer jsonDeserializer = new JsonDeserializer<>(Resource.class, false);
         jsonDeserializer.addTrustedPackages("*");
 
-        return new DefaultKafkaConsumerFactory<String, Object>(consumerConfigs(), new StringDeserializer(), jsonDeserializer);
+        return new DefaultKafkaConsumerFactory<String, Resource>(consumerConfigs(), new StringDeserializer(), jsonDeserializer);
     }
 
     @Bean

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/config/ConsumerConfig.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/config/ConsumerConfig.java
@@ -2,7 +2,9 @@ package de.brandwatch.minianalytics.mentiongenerator.kafka.config;
 
 
 import de.brandwatch.minianalytics.mentiongenerator.kafka.Consumer;
-import de.brandwatch.minianalytics.mentiongenerator.model.Ressource;
+import de.brandwatch.minianalytics.mentiongenerator.kafka.Producer;
+import de.brandwatch.minianalytics.mentiongenerator.model.Resource;
+import de.brandwatch.minianalytics.mentiongenerator.postgres.repository.QueryRepository;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -10,10 +12,10 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
-import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -28,7 +30,7 @@ public class ConsumerConfig {
 
     @Bean
     public Map<String, Object> consumerConfigs(){
-        Map<String, Object> props = new HashMap<String, Object>();
+        Map<String, Object> props = new HashMap<>();
 
         props.put(org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
@@ -41,22 +43,22 @@ public class ConsumerConfig {
     }
 
     @Bean
-    public DefaultKafkaConsumerFactory consumerFactory(){
-        JsonDeserializer jsonDeserializer = new JsonDeserializer<>(Ressource.class, false);
+    public ConsumerFactory<String, Object> consumerFactory(){
+        JsonDeserializer jsonDeserializer = new JsonDeserializer<>(Resource.class, false);
         jsonDeserializer.addTrustedPackages("*");
 
-        return new DefaultKafkaConsumerFactory<>(consumerConfigs(), new StringDeserializer(), jsonDeserializer);
+        return new DefaultKafkaConsumerFactory<String, Object>(consumerConfigs(), new StringDeserializer(), jsonDeserializer);
     }
 
     @Bean
-    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, Ressource>> kafkaListenerContainerFactory(){
-        ConcurrentKafkaListenerContainerFactory<String, Ressource> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, Resource>> kafkaListenerContainerFactory(){
+        ConcurrentKafkaListenerContainerFactory<String, Resource> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
         return factory;
     }
 
     @Bean
-    public Consumer consumer() throws IOException {
-        return new Consumer();
+    public Consumer consumer(QueryRepository queryRepository, Producer producer) throws IOException {
+        return new Consumer(queryRepository, producer);
     }
 }

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/config/ConsumerConfig.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/config/ConsumerConfig.java
@@ -2,6 +2,7 @@ package de.brandwatch.minianalytics.mentiongenerator.kafka.config;
 
 
 import de.brandwatch.minianalytics.mentiongenerator.kafka.Consumer;
+import de.brandwatch.minianalytics.mentiongenerator.model.Mention;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -9,9 +10,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.config.KafkaListenerContainerFactory;
-import org.springframework.kafka.core.ConsumerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.stereotype.Component;
 
 import java.util.HashMap;
@@ -30,7 +31,7 @@ public class ConsumerConfig {
 
         props.put(org.apache.kafka.clients.consumer.ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         props.put(org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, JsonDeserializer.class);
 
         props.put(org.apache.kafka.clients.consumer.ConsumerConfig.GROUP_ID_CONFIG, "mentions-generator");
         props.put(org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
@@ -39,13 +40,16 @@ public class ConsumerConfig {
     }
 
     @Bean
-    public ConsumerFactory<String, String> consumerFactory(){
-        return new DefaultKafkaConsumerFactory<String, String>(consumerConfigs());
+    public DefaultKafkaConsumerFactory consumerFactory(){
+        JsonDeserializer jsonDeserializer = new JsonDeserializer<>(Mention.class, false);
+        jsonDeserializer.addTrustedPackages("*");
+
+        return new DefaultKafkaConsumerFactory<>(consumerConfigs(), new StringDeserializer(), jsonDeserializer);
     }
 
     @Bean
-    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, String>> kafkaListenerContainerFactory(){
-        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<String, String>();
+    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, Mention>> kafkaListenerContainerFactory(){
+        ConcurrentKafkaListenerContainerFactory<String, Mention> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
         return factory;
     }

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/config/ConsumerConfig.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/config/ConsumerConfig.java
@@ -2,7 +2,7 @@ package de.brandwatch.minianalytics.mentiongenerator.kafka.config;
 
 
 import de.brandwatch.minianalytics.mentiongenerator.kafka.Consumer;
-import de.brandwatch.minianalytics.mentiongenerator.model.Mention;
+import de.brandwatch.minianalytics.mentiongenerator.model.Ressource;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -15,6 +15,7 @@ import org.springframework.kafka.listener.ConcurrentMessageListenerContainer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.stereotype.Component;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -41,21 +42,21 @@ public class ConsumerConfig {
 
     @Bean
     public DefaultKafkaConsumerFactory consumerFactory(){
-        JsonDeserializer jsonDeserializer = new JsonDeserializer<>(Mention.class, false);
+        JsonDeserializer jsonDeserializer = new JsonDeserializer<>(Ressource.class, false);
         jsonDeserializer.addTrustedPackages("*");
 
         return new DefaultKafkaConsumerFactory<>(consumerConfigs(), new StringDeserializer(), jsonDeserializer);
     }
 
     @Bean
-    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, Mention>> kafkaListenerContainerFactory(){
-        ConcurrentKafkaListenerContainerFactory<String, Mention> factory = new ConcurrentKafkaListenerContainerFactory<>();
+    public KafkaListenerContainerFactory<ConcurrentMessageListenerContainer<String, Ressource>> kafkaListenerContainerFactory(){
+        ConcurrentKafkaListenerContainerFactory<String, Ressource> factory = new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
         return factory;
     }
 
     @Bean
-    public Consumer consumer(){
+    public Consumer consumer() throws IOException {
         return new Consumer();
     }
 }

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/config/ProducerConfig.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/config/ProducerConfig.java
@@ -2,6 +2,8 @@ package de.brandwatch.minianalytics.mentiongenerator.kafka.config;
 
 
 import de.brandwatch.minianalytics.mentiongenerator.kafka.Producer;
+import de.brandwatch.minianalytics.mentiongenerator.model.Mention;
+import de.brandwatch.minianalytics.mentiongenerator.model.Ressource;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -32,13 +34,13 @@ public class ProducerConfig {
     }
 
     @Bean
-    public ProducerFactory<String, String> producerFactory() {
-        return new DefaultKafkaProducerFactory<String, String>(producerConfigs());
+    public ProducerFactory<String, Mention> producerFactory(){
+        return new DefaultKafkaProducerFactory<String, Mention>(producerConfigs());
     }
 
     @Bean
-    public KafkaTemplate<String, String> kafkaTemplate() {
-        return new KafkaTemplate<String, String>(producerFactory());
+    public KafkaTemplate<String, Mention> kafkaTemplate(){
+        return new KafkaTemplate<String, Mention>(producerFactory());
     }
 
     @Bean

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/config/ProducerConfig.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/kafka/config/ProducerConfig.java
@@ -3,7 +3,6 @@ package de.brandwatch.minianalytics.mentiongenerator.kafka.config;
 
 import de.brandwatch.minianalytics.mentiongenerator.kafka.Producer;
 import de.brandwatch.minianalytics.mentiongenerator.model.Mention;
-import de.brandwatch.minianalytics.mentiongenerator.model.Ressource;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -24,7 +23,7 @@ public class ProducerConfig {
     @Bean
     public Map<String, Object> producerConfigs() {
 
-        Map<String, Object> producerConfig = new HashMap<String, Object>();
+        Map<String, Object> producerConfig = new HashMap<>();
 
         producerConfig.put(org.apache.kafka.clients.producer.ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         producerConfig.put(org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -35,16 +34,16 @@ public class ProducerConfig {
 
     @Bean
     public ProducerFactory<String, Mention> producerFactory(){
-        return new DefaultKafkaProducerFactory<String, Mention>(producerConfigs());
+        return new DefaultKafkaProducerFactory<>(producerConfigs());
     }
 
     @Bean
     public KafkaTemplate<String, Mention> kafkaTemplate(){
-        return new KafkaTemplate<String, Mention>(producerFactory());
+        return new KafkaTemplate<>(producerFactory());
     }
 
     @Bean
-    public Producer producer() {
-        return new Producer();
+    public Producer producer(KafkaTemplate<String, Mention> kafkaTemplate) {
+        return new Producer(kafkaTemplate);
     }
 }

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/model/Mention.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/model/Mention.java
@@ -2,11 +2,10 @@ package de.brandwatch.minianalytics.mentiongenerator.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.InstantSerializer;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public class Mention {
 
@@ -15,9 +14,9 @@ public class Mention {
     private String author;
     private String text;
 
-    @JsonSerialize(using = LocalDateTimeSerializer.class)
-    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-    private LocalDateTime date;
+    @JsonSerialize(using = InstantSerializer.class)
+    @JsonDeserialize(using = InstantDeserializer.class)
+    private Instant date;
 
     public Mention() {
     }
@@ -38,11 +37,11 @@ public class Mention {
         this.text = text;
     }
 
-    public LocalDateTime getDate() {
+    public Instant getDate() {
         return date;
     }
 
-    public void setDate(LocalDateTime date) {
+    public void setDate(Instant date) {
         this.date = date;
     }
 

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/model/Mention.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/model/Mention.java
@@ -1,0 +1,55 @@
+package de.brandwatch.minianalytics.mentiongenerator.model;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+
+import java.time.LocalDateTime;
+
+public class Mention {
+
+    private String author;
+    private String text;
+
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    private LocalDateTime date;
+
+    public Mention() {
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(String author) {
+        this.author = author;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public LocalDateTime getDate() {
+        return date;
+    }
+
+    public void setDate(LocalDateTime date) {
+        this.date = date;
+    }
+
+    @Override
+    public String toString() {
+        return "{\n" +
+                "\tauthor: " + getAuthor() + "\n" +
+                "\ttext: " + getText() + "\n" +
+                "\tdate: " + getDate().toString() + "\n" +
+                "}";
+    }
+}

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/model/Resource.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/model/Resource.java
@@ -6,9 +6,8 @@ import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.InstantSerializer;
 
 import java.time.Instant;
-import java.time.LocalDateTime;
 
-public class Ressource {
+public class Resource {
 
     private String author;
     private String text;
@@ -17,7 +16,7 @@ public class Ressource {
     @JsonDeserialize(using = InstantDeserializer.class)
     private Instant date;
 
-    public Ressource() {
+    public Resource() {
     }
 
     public String getAuthor() {

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/model/Ressource.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/model/Ressource.java
@@ -2,10 +2,10 @@ package de.brandwatch.minianalytics.mentiongenerator.model;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateSerializer;
-import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import com.fasterxml.jackson.datatype.jsr310.deser.InstantDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.InstantSerializer;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 
 public class Ressource {
@@ -13,9 +13,9 @@ public class Ressource {
     private String author;
     private String text;
 
-    @JsonSerialize(using = LocalDateTimeSerializer.class)
-    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
-    private LocalDateTime date;
+    @JsonSerialize(using = InstantSerializer.class)
+    @JsonDeserialize(using = InstantDeserializer.class)
+    private Instant date;
 
     public Ressource() {
     }
@@ -36,11 +36,11 @@ public class Ressource {
         this.text = text;
     }
 
-    public LocalDateTime getDate() {
+    public Instant getDate() {
         return date;
     }
 
-    public void setDate(LocalDateTime date) {
+    public void setDate(Instant date) {
         this.date = date;
     }
 

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/model/Ressource.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/model/Ressource.java
@@ -8,9 +8,7 @@ import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 
 import java.time.LocalDateTime;
 
-public class Mention {
-
-    private long queryID;
+public class Ressource {
 
     private String author;
     private String text;
@@ -19,7 +17,7 @@ public class Mention {
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     private LocalDateTime date;
 
-    public Mention() {
+    public Ressource() {
     }
 
     public String getAuthor() {
@@ -46,18 +44,9 @@ public class Mention {
         this.date = date;
     }
 
-    public long getQueryID() {
-        return queryID;
-    }
-
-    public void setQueryID(long queryID) {
-        this.queryID = queryID;
-    }
-
     @Override
     public String toString() {
         return "{\n" +
-                "\tqueryID: " + getQueryID() + "\n" +
                 "\tauthor: " + getAuthor() + "\n" +
                 "\ttext: " + getText() + "\n" +
                 "\tdate: " + getDate().toString() + "\n" +

--- a/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/postgres/model/Query.java
+++ b/mentions-generator/src/main/java/de/brandwatch/minianalytics/mentiongenerator/postgres/model/Query.java
@@ -20,4 +20,25 @@ public class Query {
 
     public Query() {
     }
+
+    public long getQueryID() {
+        return queryID;
+    }
+
+    public void setQueryID(long queryID) {
+        this.queryID = queryID;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    @Override
+    public String toString() {
+        return query;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,31 @@
                 <version>2.1</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.9.9</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-core</artifactId>
+                <version>7.1.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-queryparser</artifactId>
+                <version>8.2.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.lucene</groupId>
+                <artifactId>lucene-analyzers-common</artifactId>
+                <version>8.2.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>2.9.9</version>
+            </dependency>
+            <dependency>
                 <groupId>org.twitter4j</groupId>
                 <artifactId>twitter4j-stream</artifactId>
                 <version>4.0.6</version>

--- a/twitterpuller/src/main/java/de/brandwatch/minianalytics/twitterpuller/kafka/Producer.java
+++ b/twitterpuller/src/main/java/de/brandwatch/minianalytics/twitterpuller/kafka/Producer.java
@@ -16,6 +16,6 @@ public class Producer {
     public void send(Resource resource){
 
         logger.info("sending message='{}'", resource.toString());
-        kafkaTemplate.send("twitter", String.valueOf(System.currentTimeMillis()), resource);
+        kafkaTemplate.send("resources", String.valueOf(System.currentTimeMillis()), resource);
     }
 }


### PR DESCRIPTION
Change the `receive` method of the mentions-generator Kafka consumer. The Consumer is now able to receive JSON Resources from the Twitter-Puller and perform a lucene search over this resource. When the lucene search concludes that the Resources matches the Query it generates a Mention from the resource an publishes it on the mentions kafka topic.

Project Board Card: https://github.com/Max-Leopold/mini-analytics/projects/1#card-25214848