### PR TITLE
Add Spring Security and user authentification

### DIFF
--- a/API/pom.xml
+++ b/API/pom.xml
@@ -43,6 +43,38 @@
       <artifactId>gson</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.thymeleaf.extras</groupId>
+      <artifactId>thymeleaf-extras-springsecurity5</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.thymeleaf</groupId>
+      <artifactId>thymeleaf-spring5</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>

--- a/API/pom.xml
+++ b/API/pom.xml
@@ -43,21 +43,6 @@
       <artifactId>gson</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>postgresql</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>testcontainers</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.testcontainers</groupId>
-      <artifactId>junit-jupiter</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/API/src/main/java/de/brandwatch/minianalytics/api/controller/MentionController.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/controller/MentionController.java
@@ -2,6 +2,7 @@ package de.brandwatch.minianalytics.api.controller;
 
 
 import com.google.common.base.Preconditions;
+import de.brandwatch.minianalytics.api.security.service.ValidationService;
 import de.brandwatch.minianalytics.api.service.MentionService;
 import de.brandwatch.minianalytics.api.solr.model.Mention;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,9 +25,12 @@ public class MentionController {
 
     private final MentionService mentionService;
 
+    private final ValidationService validationService;
+
     @Autowired
-    public MentionController(MentionService mentionService) {
+    public MentionController(MentionService mentionService, ValidationService validationService) {
         this.mentionService = mentionService;
+        this.validationService = validationService;
     }
 
     @GetMapping(value = "/mentions/{queryID}")
@@ -41,6 +45,7 @@ public class MentionController {
             Instant parsedEndDate = parseOrDefault(endDate, 0);
 
             validateDates(parsedStartDate, parsedEndDate);
+            validationService.validateUser(queryID);
 
             return mentionService.getMentionsFromQueryID(queryID, parsedStartDate, parsedEndDate);
         } catch (Exception e) {

--- a/API/src/main/java/de/brandwatch/minianalytics/api/controller/QueryController.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/controller/QueryController.java
@@ -1,8 +1,8 @@
 package de.brandwatch.minianalytics.api.controller;
 
 import com.google.gson.Gson;
-import de.brandwatch.minianalytics.api.postgres.model.Query;
 import com.google.gson.GsonBuilder;
+import de.brandwatch.minianalytics.api.postgres.model.Query;
 import de.brandwatch.minianalytics.api.service.QueryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -20,7 +20,7 @@ public class QueryController {
 
     private static final Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
 
-    private QueryService queryService;
+    private final QueryService queryService;
 
     @Autowired
     public QueryController(QueryService queryService) {
@@ -28,7 +28,7 @@ public class QueryController {
     }
 
     @PostMapping(value = "/queries")
-    public Query query(@RequestParam String query) {
+    public Query createQuery(@RequestParam String query) {
         try {
             logger.info("POST /queries: {}", query);
             return queryService.createQuery(query);

--- a/API/src/main/java/de/brandwatch/minianalytics/api/controller/QueryController.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/controller/QueryController.java
@@ -2,6 +2,7 @@ package de.brandwatch.minianalytics.api.controller;
 
 import com.google.gson.Gson;
 import de.brandwatch.minianalytics.api.postgres.model.Query;
+import com.google.gson.GsonBuilder;
 import de.brandwatch.minianalytics.api.service.QueryService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,13 +13,12 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
 
-
 @RestController
 public class QueryController {
 
     private static final Logger logger = LoggerFactory.getLogger(QueryController.class);
 
-    private static final Gson gson = new Gson();
+    private static final Gson gson = new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
 
     private QueryService queryService;
 

--- a/API/src/main/java/de/brandwatch/minianalytics/api/controller/UserController.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/controller/UserController.java
@@ -1,0 +1,44 @@
+package de.brandwatch.minianalytics.api.controller;
+
+import de.brandwatch.minianalytics.api.security.model.User;
+import de.brandwatch.minianalytics.api.security.service.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@Controller
+public class UserController {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserController.class);
+
+    private UserService userService;
+
+    @Autowired
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    @GetMapping(value = "/registration")
+    public String registration(Model model) {
+        model.addAttribute("userForm", new User());
+        return "registration";
+    }
+
+    @PostMapping(value = "/registration")
+    public String registerNewUser(User user) {
+        try {
+            userService.checkForUsernameDuplicate(user.getUsername());
+            userService.save(user);
+
+            return "redirect:/login";
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+        }
+
+        return "registration";
+    }
+}

--- a/API/src/main/java/de/brandwatch/minianalytics/api/controller/WebController.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/controller/WebController.java
@@ -15,4 +15,10 @@ public class WebController {
     public String index() {
         return "index";
     }
+
+    @GetMapping(value = "/login")
+    public String login() {
+        return "login";
+    }
+
 }

--- a/API/src/main/java/de/brandwatch/minianalytics/api/postgres/model/Query.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/postgres/model/Query.java
@@ -1,5 +1,6 @@
 package de.brandwatch.minianalytics.api.postgres.model;
 
+import com.google.gson.annotations.Expose;
 import de.brandwatch.minianalytics.api.security.model.User;
 
 import javax.persistence.*;
@@ -11,9 +12,11 @@ public class Query {
     @Id
     @GeneratedValue
     @Column(name = "queryID")
+    @Expose
     private long queryID;
 
     @Column(name = "query")
+    @Expose
     private String query;
 
     @ManyToOne(targetEntity = User.class, fetch = FetchType.EAGER)

--- a/API/src/main/java/de/brandwatch/minianalytics/api/postgres/model/Query.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/postgres/model/Query.java
@@ -1,5 +1,7 @@
 package de.brandwatch.minianalytics.api.postgres.model;
 
+import de.brandwatch.minianalytics.api.security.model.User;
+
 import javax.persistence.*;
 
 @Entity
@@ -14,11 +16,39 @@ public class Query {
     @Column(name = "query")
     private String query;
 
-    public Query(String query) {
+    @ManyToOne(targetEntity = User.class, fetch = FetchType.EAGER)
+    private User user;
+
+    public Query(String query, User user) {
         this.query = query;
+        this.user = user;
     }
 
     public Query() {
+    }
+
+    public long getQueryID() {
+        return queryID;
+    }
+
+    public void setQueryID(long queryID) {
+        this.queryID = queryID;
+    }
+
+    public String getQuery() {
+        return query;
+    }
+
+    public void setQuery(String query) {
+        this.query = query;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
     }
 
     @Override

--- a/API/src/main/java/de/brandwatch/minianalytics/api/postgres/repository/QueryRepository.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/postgres/repository/QueryRepository.java
@@ -3,6 +3,10 @@ package de.brandwatch.minianalytics.api.postgres.repository;
 import de.brandwatch.minianalytics.api.postgres.model.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 
 public interface QueryRepository extends JpaRepository<Query, Long> {
+
+    List<Query> findByUserId(Long userId);
 }

--- a/API/src/main/java/de/brandwatch/minianalytics/api/security/config/SecurityConfig.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/security/config/SecurityConfig.java
@@ -1,0 +1,50 @@
+package de.brandwatch.minianalytics.api.security.config;
+
+import de.brandwatch.minianalytics.api.security.service.CustomUserDetailsService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    private CustomUserDetailsService userDetailsService;
+
+    @Autowired
+    public SecurityConfig(CustomUserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+                .csrf().disable()
+                .authorizeRequests().antMatchers("/register").permitAll()
+                .and()
+                .authorizeRequests().antMatchers("/", "/index").authenticated().and()
+                .formLogin()
+                .loginPage("/login");
+    }
+
+    @Bean
+    public BCryptPasswordEncoder bCryptPasswordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager customAuthenticationManager() throws Exception {
+        return authenticationManager();
+    }
+
+    @Autowired
+    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+        auth.userDetailsService(userDetailsService).passwordEncoder(bCryptPasswordEncoder());
+    }
+}

--- a/API/src/main/java/de/brandwatch/minianalytics/api/security/model/Role.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/security/model/Role.java
@@ -1,0 +1,31 @@
+package de.brandwatch.minianalytics.api.security.model;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+public class Role {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/API/src/main/java/de/brandwatch/minianalytics/api/security/model/User.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/security/model/User.java
@@ -1,0 +1,52 @@
+package de.brandwatch.minianalytics.api.security.model;
+
+import javax.persistence.*;
+import java.util.Set;
+
+@Entity
+@Table(name = "UserTable")
+public class User {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String username;
+
+    private String password;
+
+    @ManyToMany(fetch = FetchType.EAGER)
+    private Set<Role> roles;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    public Set<Role> getRoles() {
+        return roles;
+    }
+
+    public void setRoles(Set<Role> roles) {
+        this.roles = roles;
+    }
+}

--- a/API/src/main/java/de/brandwatch/minianalytics/api/security/repositories/RoleRepository.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/security/repositories/RoleRepository.java
@@ -1,0 +1,7 @@
+package de.brandwatch.minianalytics.api.security.repositories;
+
+import de.brandwatch.minianalytics.api.security.model.Role;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoleRepository extends JpaRepository<Role, Long> {
+}

--- a/API/src/main/java/de/brandwatch/minianalytics/api/security/repositories/UserRepository.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/security/repositories/UserRepository.java
@@ -1,0 +1,8 @@
+package de.brandwatch.minianalytics.api.security.repositories;
+
+import de.brandwatch.minianalytics.api.security.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    User findByUsername(String username);
+}

--- a/API/src/main/java/de/brandwatch/minianalytics/api/security/service/CustomUserDetailsService.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/security/service/CustomUserDetailsService.java
@@ -27,7 +27,9 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         User user = userRepository.findByUsername(username);
-        if(user == null) throw new UsernameNotFoundException(username);
+        if(user == null) {
+            throw new UsernameNotFoundException(username);
+        }
 
         Set<GrantedAuthority> grantedAuthorities = new HashSet<>();
         for (Role role : user.getRoles()){

--- a/API/src/main/java/de/brandwatch/minianalytics/api/security/service/CustomUserDetailsService.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/security/service/CustomUserDetailsService.java
@@ -1,0 +1,39 @@
+package de.brandwatch.minianalytics.api.security.service;
+
+import de.brandwatch.minianalytics.api.security.model.Role;
+import de.brandwatch.minianalytics.api.security.model.User;
+import de.brandwatch.minianalytics.api.security.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username);
+        if(user == null) throw new UsernameNotFoundException(username);
+
+        Set<GrantedAuthority> grantedAuthorities = new HashSet<>();
+        for (Role role : user.getRoles()){
+            grantedAuthorities.add(new SimpleGrantedAuthority(role.getName()));
+        }
+
+        return new org.springframework.security.core.userdetails.User(user.getUsername(), user.getPassword(), grantedAuthorities);
+    }
+}

--- a/API/src/main/java/de/brandwatch/minianalytics/api/security/service/UserService.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/security/service/UserService.java
@@ -1,0 +1,37 @@
+package de.brandwatch.minianalytics.api.security.service;
+
+import de.brandwatch.minianalytics.api.security.model.User;
+import de.brandwatch.minianalytics.api.security.repositories.RoleRepository;
+import de.brandwatch.minianalytics.api.security.repositories.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+
+@Service
+public class UserService {
+
+    private UserRepository userRepository;
+
+    private RoleRepository roleRepository;
+
+    private BCryptPasswordEncoder bCryptPasswordEncoder;
+
+    @Autowired
+    public UserService(UserRepository userRepository, RoleRepository roleRepository, BCryptPasswordEncoder bCryptPasswordEncoder) {
+        this.userRepository = userRepository;
+        this.roleRepository = roleRepository;
+        this.bCryptPasswordEncoder = bCryptPasswordEncoder;
+    }
+
+    public void save(User user) {
+        user.setPassword(bCryptPasswordEncoder.encode(user.getPassword()));
+        user.setRoles(new HashSet<>(roleRepository.findAll()));
+        userRepository.save(user);
+    }
+
+    public void checkForUsernameDuplicate(String username) throws Exception {
+        if(userRepository.findByUsername(username) == null) throw new Exception("Duplicate username");
+    }
+}

--- a/API/src/main/java/de/brandwatch/minianalytics/api/security/service/UserService.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/security/service/UserService.java
@@ -32,6 +32,6 @@ public class UserService {
     }
 
     public void checkForUsernameDuplicate(String username) throws Exception {
-        if(userRepository.findByUsername(username) == null) throw new Exception("Duplicate username");
+        if(!(userRepository.findByUsername(username) == null)) throw new Exception("Duplicate username");
     }
 }

--- a/API/src/main/java/de/brandwatch/minianalytics/api/security/service/ValidationService.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/security/service/ValidationService.java
@@ -1,0 +1,30 @@
+package de.brandwatch.minianalytics.api.security.service;
+
+import com.google.common.base.Preconditions;
+import de.brandwatch.minianalytics.api.postgres.repository.QueryRepository;
+import de.brandwatch.minianalytics.api.security.model.User;
+import de.brandwatch.minianalytics.api.security.repositories.UserRepository;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ValidationService {
+
+    private final UserRepository userRepository;
+
+    private final QueryRepository queryRepository;
+
+    public ValidationService(UserRepository userRepository, QueryRepository queryRepository) {
+        this.userRepository = userRepository;
+        this.queryRepository = queryRepository;
+    }
+
+    public void validateUser(String queryID) {
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String username = ((UserDetails) principal).getUsername();
+        User user = userRepository.findByUsername(username);
+        Preconditions.checkArgument(queryRepository.findById(Long.valueOf(queryID)).get().getUser().equals(user),
+                "Query " + queryID + "doesn't belong to user " + username);
+    }
+}

--- a/API/src/main/java/de/brandwatch/minianalytics/api/service/QueryService.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/service/QueryService.java
@@ -2,9 +2,13 @@ package de.brandwatch.minianalytics.api.service;
 
 import de.brandwatch.minianalytics.api.postgres.model.Query;
 import de.brandwatch.minianalytics.api.postgres.repository.QueryRepository;
+import de.brandwatch.minianalytics.api.security.model.User;
+import de.brandwatch.minianalytics.api.security.repositories.UserRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -17,23 +21,47 @@ public class QueryService {
 
     private final QueryRepository queryRepository;
 
+    private final UserRepository userRepository;
+
     @Autowired
-    public QueryService(QueryRepository queryRepository) {
+    public QueryService(QueryRepository queryRepository, UserRepository userRepository) {
         this.queryRepository = queryRepository;
+        this.userRepository = userRepository;
     }
 
     public Query createQuery(String query) {
-        Query saveQuery = new Query(query);
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String username = ((UserDetails) principal).getUsername();
+
+        User user = userRepository.findByUsername(username);
+        Query saveQuery = new Query(query, user);
 
         logger.info("Retrieved query: " + query);
         return queryRepository.save(saveQuery);
     }
 
     public List<Query> getAllQueries() {
-        return queryRepository.findAll();
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String username = ((UserDetails) principal).getUsername();
+
+        User user = userRepository.findByUsername(username);
+        Long userId = user.getId();
+
+        return queryRepository.findByUserId(userId);
     }
 
     public Optional<Query> getQueryByID(String queryID) {
-        return queryRepository.findById(Long.valueOf(queryID));
+
+        Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        String username = ((UserDetails) principal).getUsername();
+
+        User user = userRepository.findByUsername(username);
+        Long userId = user.getId();
+
+        Optional<Query> query = queryRepository.findById(Long.valueOf(queryID));
+
+        if(query.isPresent() && query.get().getUser().getId().equals(userId)) return queryRepository.findById(Long.valueOf(queryID));
+
+        return Optional.empty();
     }
 }

--- a/API/src/main/java/de/brandwatch/minianalytics/api/service/QueryService.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/service/QueryService.java
@@ -60,7 +60,9 @@ public class QueryService {
 
         Optional<Query> query = queryRepository.findById(Long.valueOf(queryID));
 
-        if(query.isPresent() && query.get().getUser().getId().equals(userId)) return queryRepository.findById(Long.valueOf(queryID));
+        if(query.isPresent() && query.get().getUser().getId().equals(userId)) {
+            return queryRepository.findById(Long.valueOf(queryID));
+        }
 
         throw new Exception("Query " + queryID + " doesnt belong to user " + username);
     }

--- a/API/src/main/java/de/brandwatch/minianalytics/api/service/QueryService.java
+++ b/API/src/main/java/de/brandwatch/minianalytics/api/service/QueryService.java
@@ -50,7 +50,7 @@ public class QueryService {
         return queryRepository.findByUserId(userId);
     }
 
-    public Optional<Query> getQueryByID(String queryID) {
+    public Optional<Query> getQueryByID(String queryID) throws Exception {
 
         Object principal = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
         String username = ((UserDetails) principal).getUsername();
@@ -62,6 +62,6 @@ public class QueryService {
 
         if(query.isPresent() && query.get().getUser().getId().equals(userId)) return queryRepository.findById(Long.valueOf(queryID));
 
-        return Optional.empty();
+        throw new Exception("Query " + queryID + " doesnt belong to user " + username);
     }
 }

--- a/API/src/main/resources/application.properties
+++ b/API/src/main/resources/application.properties
@@ -15,3 +15,7 @@ spring.jpa.generate-ddl=true
 spring.datasource.driverClassName=org.postgresql.Driver
 
 spring.jpa.show-sql=true
+
+logging.level.org.springframework.security=INFO
+
+spring.messages.basename=validation

--- a/API/src/main/resources/templates/index.html
+++ b/API/src/main/resources/templates/index.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
-<html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org"
+      xmlns:sec="https://www.thymeleaf.org/thymeleaf-extras-springsecurity3">
 <head>
     <meta charset="ISO-8859-1"/>
 </head>
 <body>
+<div sec:authorize="isAuthenticated()">Logged in as <span sec:authentication="name"></span></div>
+<br>
 Query: <input type="text" size="50" id="createQueryInput">
 <input type="button" value="Create new Query" onclick="createQuery()">
 <div id="createQueryDiv"></div>
@@ -28,6 +31,9 @@ To Date (Optional): <input type="date" id="datePickerTo">
 <br>
 <textarea id="getMentionsFromQueryDiv" rows="15" cols="80">
 </textarea>
+<form th:action="@{/logout}" method="post">
+    <input type="submit" value="Sign Out"/>
+</form>
 </body>
 <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 <script>

--- a/API/src/main/resources/templates/login.html
+++ b/API/src/main/resources/templates/login.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:th="https://www.thymeleaf.org"
+>
+<head>
+    <title>Spring Security Example </title>
+</head>
+<body>
+<div th:if="${param.error}">
+    Invalid username and password.
+</div>
+<div th:if="${param.logout}">
+    You have been logged out.
+</div>
+<form th:action="@{/login}" method="post">
+    <div><label> User Name : <input type="text" name="username"/> </label></div>
+    <br>
+    <div><label> Password: <input type="password" name="password"/> </label></div>
+    <div><input type="submit" value="Sign In"/></div>
+</form>
+<br>
+<div>
+    <form action="http://localhost:8080/registration">
+        <input type="submit" value="Create an account"/>
+    </form>
+</div>
+</body>
+</html>

--- a/API/src/main/resources/templates/registration.html
+++ b/API/src/main/resources/templates/registration.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml"
+>
+<head>
+    <meta charset="UTF-8">
+    <title>Title</title>
+</head>
+<body>
+    <div id="accountCreatedDiv"></div>
+    <div><label> User Name : <input type="text" name="username" id="userNameInput"/> </label></div>
+    <br>
+    <div><label> Password: <input type="password" name="password" id="passwordInput"/> </label></div>
+    <div><input type="submit" value="Sign up" onclick="registerUser()"/></div>
+    <br>
+    <div>
+        <form action="http://localhost:8080/login">
+            <input type="submit" value="Login"/>
+        </form>
+    </div>
+</body>
+<script src="https://unpkg.com/axios/dist/axios.min.js"></script>
+<script>
+    function registerUser() {
+        var username = document.getElementById("userNameInput").value;
+        var password = document.getElementById("passwordInput").value;
+
+        axios.post('http://localhost:8080/registration', null, {
+            params: {
+                username: username,
+                password: password
+            }
+        }).then(function (response) {
+            console.log(response);
+            if(response.status === 200){
+                document.getElementById("accountCreatedDiv").innerHTML = "Successfully created account"
+            }else {
+                document.getElementById("accountCreatedDiv").innerHTML = "Sorry, there was an error creating your account"
+            }
+        })
+    }
+</script>
+</html>


### PR DESCRIPTION
Add user authentification through spring security to the application.

You can't view queries or mentions without being logged in. Queries are now bound to user accounts. You can only retrieve queries and their mentions if you wrote the query.

When logged in Spring saves the Credentials of the user in the browser. When a call is made  the `Spring Security Context` is sent to the endpoint inside the Http Request.

Example:

`Session Attrs = {SPRING_SECURITY_CONTEXT=org.springframework.security.core.context.SecurityContextImpl@fd6e26c: Authentication: org.springframework.security.authentication.UsernamePasswordAuthenticationToken@fd6e26c: Principal: org.springframework.security.core.userdetails.User@f02988d6: Username: username; Password: [PROTECTED]; Enabled: true; AccountNonExpired: true; credentialsNonExpired: true; AccountNonLocked: true; Not granted any authorities; Credentials: [PROTECTED]; Authenticated: true; Details: org.springframework.security.web.authentication.WebAuthenticationDetails@957e: RemoteIpAddress: 127.0.0.1; SessionId: null; Not granted any authorities}`